### PR TITLE
441 - Fix event model bugs

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -32,12 +32,9 @@ class Event < ActiveRecord::Base
 
   def self.future_events
     Event.where("start_date_and_time > ?", Date.today.beginning_of_day)
+      .order("start_date_and_time")
       .includes(:attendances)
       .select(&:not_over?)
-  end
-
-  def attendees_by_school(school)
-    attendees.select { |attendee| attendee.school == school }.count
   end
 
   def not_over?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,13 +6,6 @@ class Event < ActiveRecord::Base
   TYPES = %w(Football Camp Recreational Basketball Tennis Aquatic Gymnastics
              Fitness Other)
 
-  def self.popular_events_by_school(school, number)
-    popular_events = Event.future_events.sort_by do |event|
-      -event.attendees.select { |attendee| attendee.school == school }.size
-    end
-    popular_events[0...number]
-  end
-
   def self.popular_events(number)
     Event.select('events.*, count(attendances.id) AS attendance_count')
       .joins(:attendances)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,8 +3,6 @@ class Event < ActiveRecord::Base
   has_many    :attendances
   has_many    :attendees , through: :attendances, source: :student
 
-  default_scope { order("start_date_and_time") }
-
   TYPES = %w(Football Camp Recreational Basketball Tennis Aquatic Gymnastics
              Fitness Other)
 
@@ -27,11 +25,13 @@ class Event < ActiveRecord::Base
   def self.by_time(start_time, end_time)
     if end_time
       Event.where("start_date_and_time BETWEEN ? AND ?", start_time, end_time)
+        .order("start_date_and_time")
         .includes(:attendances)
         .select(&:not_over?)
     else
       Event.where("start_date_and_time BETWEEN ? AND ?",
             start_time.to_date.beginning_of_day, start_time.to_date.end_of_day)
+        .order("start_date_and_time")
         .includes(:attendances)
         .select(&:not_over?)
     end
@@ -48,7 +48,7 @@ class Event < ActiveRecord::Base
   end
 
   def not_over?
-    (start_date_and_time + duration).future?
+    (start_date_and_time + duration.hours).future?
   end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,8 @@ class Event < ActiveRecord::Base
   has_many    :attendances
   has_many    :attendees , through: :attendances, source: :student
 
+  default_scope { order("start_date_and_time") }
+
   TYPES = %w(Football Camp Recreational Basketball Tennis Aquatic Gymnastics
              Fitness Other)
 
@@ -26,12 +28,11 @@ class Event < ActiveRecord::Base
     if end_time
       Event.where("start_date_and_time BETWEEN ? AND ?", start_time, end_time)
         .includes(:attendances)
-        .order("start_date_and_time")
         .select(&:not_over?)
     else
-      Event.where(start_date_and_time: start_time)
+      Event.where("start_date_and_time BETWEEN ? AND ?",
+            start_time.to_date.beginning_of_day, start_time.to_date.end_of_day)
         .includes(:attendances)
-        .order("start_date_and_time")
         .select(&:not_over?)
     end
   end
@@ -39,7 +40,6 @@ class Event < ActiveRecord::Base
   def self.future_events
     Event.where("start_date_and_time > ?", Date.today.beginning_of_day)
       .includes(:attendances)
-      .order("start_date_and_time")
       .select(&:not_over?)
   end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe EventsController do
+  let(:student) do
+    student = create(:student)
+    student.user.update(phone_verified: true, email_verified: true)
+    student
+  end
+
+  describe "GET #index" do
+    before do
+      @event1 = create(:event, start_date_and_time: 1.day.ago)
+      @event2 = create(:event, start_date_and_time: 1.day.from_now)
+      @event3 = create(:event, start_date_and_time: 5.days.from_now)
+      @event4 = create(:event, start_date_and_time: 10.days.from_now)
+    end
+
+    context "with no parameters" do
+      #before { get :index }
+      #specify { expect(assigns(:events).size).to eq(3) }
+    end
+
+    context "with start time parameter" do
+      before { get :index, { start_time: "2015-09-30 00:00:00 -0500" }, user_id: student.user.id }
+      specify { expect(response).to render_template('index') }
+      specify { expect(assigns(:events)).to eq(@event2) }
+      specify { expect(assigns(:events)).to include(@event2) }
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -18,6 +18,14 @@ FactoryGirl.define do
     user_attributes { FactoryGirl.attributes_for(:user) }
   end
 
+  factory :service_provider do
+    user_attributes { FactoryGirl.attributes_for(:user) }
+  end
+
+  factory :admin do
+    user_attributes { FactoryGirl.attributes_for(:user) }
+  end
+
   factory :school do
     name { "#{Faker::Company.name} High School" }
     address { "#{Faker::Address.street_address}, Chicago, IL" }

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -4,6 +4,11 @@ FactoryGirl.define do
     phone { "555#{Array.new(7) { rand(10).to_s }.join}"}
     password "password1234"
     password_confirmation "password1234"
+
+    factory :verified_user do
+      email_verified true
+      phone_verified true
+    end
   end
 
   factory :student do
@@ -12,10 +17,18 @@ FactoryGirl.define do
     home_address { "#{Faker::Address.street_address}, Chicago, IL" }
     user_attributes { FactoryGirl.attributes_for(:user) }
     nudges_enabled true
+
+    factory :verified_student do
+      user_attributes { FactoryGirl.attributes_for(:verified_user) }
+    end
   end
 
   factory :parent do
     user_attributes { FactoryGirl.attributes_for(:user) }
+
+    factory :verified_parent do
+      user_attributes { FactoryGirl.attributes_for(:verified_user) }
+    end
   end
 
   factory :service_provider do
@@ -42,12 +55,13 @@ FactoryGirl.define do
 
   factory :attendance do
     event_id { create(:event).id }
-    student_id { create(:student).id }
+    student_id { create(:verified_student).id }
+    commitment_status { "Yes" }
   end
 
   factory :nudge do
-    nudger_id { create(:student).id }
-    nudgee_id { create(:student).id }
+    nudger_id { create(:verified_student).id }
+    nudgee_id { create(:verified_student).id }
     event_id { create(:event).id }
   end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Admin, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "is invalid without a user" do
+    expect(build(:parent, user_attributes: {})).not_to be_valid
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -40,4 +40,18 @@ RSpec.describe Event, type: :model do
       expect(Event.future_events).to eq([@event2, @event3, @event4, @event5, @event6])
     end
   end
+
+  describe "#not_over?" do
+    it "returns true if an event is in progress" do
+      expect(@event2.not_over?).to be true
+    end
+
+    it "returns true if an event has not yet started" do
+      expect(@event6.not_over?).to be true
+    end
+
+    it "returns false if an event has ended" do
+      expect(@event1.not_over?).to be false
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  before do
+    @event1 = create(:event, name: "event1", start_date_and_time: 1.day.ago)
+    @event2 = create(:event, name: "event2", start_date_and_time: 1.hour.ago, duration: 3)
+    @event3 = create(:event, name: "event3", start_date_and_time: 1.day.from_now.beginning_of_day)
+    @event4 = create(:event, name: "event4", start_date_and_time: 1.day.from_now.at_midday)
+    @event5 = create(:event, name: "event5", start_date_and_time: 5.days.from_now)
+    @event6 = create(:event, name: "event6", start_date_and_time: 10.days.from_now)
+    5.times { create(:attendance, event_id: @event1.id) }
+    4.times { create(:attendance, event_id: @event5.id) }
+    3.times { create(:attendance, event_id: @event3.id) }
+    2.times { create(:attendance, event_id: @event4.id) }
+  end
+
+  describe "::popular_events" do
+    it "finds the n most popular events that have not yet started" do
+      expect(Event.popular_events(3)).to eq([@event5, @event3, @event4])
+    end
+  end
+
+  describe "::by_time" do
+    context "when only a start datetime is provided" do
+      it "finds all events on that day" do
+        expect(Event.by_time(Date.tomorrow, nil)).to eq([@event3, @event4])
+      end
+    end
+
+    context "when both start and end datetimes are provided" do
+      it "finds all events between those times" do
+        events = Event.by_time(Date.tomorrow, Date.today + 7.days)
+        expect(events).to eq([@event3, @event4, @event5])
+      end
+    end
+  end
+
+  describe "::future_events" do
+    it "finds all events that have not ended yet" do
+      expect(Event.future_events).to eq([@event2, @event3, @event4, @event5, @event6])
+    end
+  end
+end

--- a/spec/models/parent_spec.rb
+++ b/spec/models/parent_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Parent, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "is invalid without a user" do
+    expect(build(:parent, user_attributes: {})).not_to be_valid
+  end
 end

--- a/spec/models/service_provider_spec.rb
+++ b/spec/models/service_provider_spec.rb
@@ -1,5 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ServiceProvider, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it "is invalid without a user" do
+    expect(build(:parent, user_attributes: {})).not_to be_valid
+  end
 end


### PR DESCRIPTION
Fixes two bugs:
* Searching for events with one datetime parameter will now return all events starting on that day, as intended, rather than only events starting at that exact time
* The `#not_over?` method now interprets duration correctly (i.e., as a number of hours, and not days)

Also creates Event model and EventsController specs.