### PR TITLE
Use unicorn in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,52 +1,23 @@
 source 'https://rubygems.org'
 
-
-# Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.1'
-# Use postgresql as the database for Active Record
 gem 'pg'
-# Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
-
-# Use jquery as the JavaScript library
 gem 'jquery-rails'
-# Use jquery mobile for faster mobile development and animations
 gem 'jquery_mobile_rails'
 gem 'icheck-rails'
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
-#rails 12Factor
-gem 'rails_12factor', group: :production
-
-# Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 gem 'figaro'
 gem 'pry'
 gem 'cane'
 gem 'simplecov'
-# Use Unicorn as the app server
-# gem 'unicorn'
-
-# Use Capistrano for deployment
-# gem 'capistrano-rails', group: :development
-
-#Using the ruby gem for twilio
 gem "twilio-ruby"
-group :development, :test do
-  # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  # gem 'byebug'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
+group :development, :test do
   gem 'web-console', '~> 2.0'
   gem 'capybara'
   gem 'selenium-webdriver'
@@ -59,4 +30,9 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl_rails', '~> 4.0'
   gem 'shoulda-matchers'
+end
+
+group :production do
+  gem 'rails_12factor'
+  gem 'unicorn'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
       railties (>= 3.1.0)
     json (1.8.3)
     jwt (1.5.1)
+    kgio (2.10.0)
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -148,6 +149,7 @@ GEM
       activesupport (= 4.2.1)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.15.0)
     rake (10.4.2)
     rdoc (4.2.0)
     rspec-core (3.3.2)
@@ -209,6 +211,10 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unicorn (4.9.0)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     web-console (2.2.1)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -250,4 +256,5 @@ DEPENDENCIES
   simplecov
   twilio-ruby
   uglifier (>= 1.3.0)
+  unicorn
   web-console (~> 2.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT -c ./config/unicorn.rb

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,22 @@
+worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
+timeout 15
+preload_app true
+
+before_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
+end
+
+after_fork do |server, worker|
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
+end


### PR DESCRIPTION
Use unicorn in production, as WEBrick is not recommended for this.

Heroku recommends puma these days. We'll use unicorn for now so we don't need to worry about thread safety (although it would probably be fine).