### PR TITLE
Separate registration views for students and service providers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_no_login
+    redirect_to home_path unless current_user.nil?
+  end
+
   def require_verified_user
     if current_user.nil?
       redirect_to login_path
@@ -32,6 +36,13 @@ class ApplicationController < ActionController::Base
   def require_student
     unless current_user && current_user.student?
       redirect_to root_path
+    end
+  end
+
+  def require_registration_enabled
+    if ENV["DISABLE_REGISTRATIONS"] == "TRUE"
+      flash[:notice] = "We're sorry, but registration is temporarily disabled."
+      redirect_to login_path
     end
   end
 
@@ -70,15 +81,6 @@ class ApplicationController < ActionController::Base
     when "Parent" then edit_parent_path
     when "ServiceProvider" then edit_service_provider_path
     end
-  end
-
-  def assign_all_role_types
-    @parent ||= Parent.new
-    @parent.build_user unless @parent.user
-    @student ||= Student.new
-    @student.build_user unless @student.user
-    @service_provider ||= ServiceProvider.new
-    @service_provider.build_user unless @service_provider.user
   end
 
   private

--- a/app/controllers/service_providers_controller.rb
+++ b/app/controllers/service_providers_controller.rb
@@ -1,16 +1,20 @@
 class ServiceProvidersController < ApplicationController
-  before_filter :require_login, :require_service_provider, except: :create
+  before_filter :require_login, :require_service_provider, except: [:new, :create]
+  before_filter :require_no_login, only: [:new, :create]
+  before_filter :require_registration_enabled, only: [:new, :create]
+
+  def new
+    @service_provider = ServiceProvider.new
+    @service_provider.build_user
+  end
 
   def create
     @service_provider = ServiceProvider.new(service_provider_params)
-    if ENV["DISABLE_REGISTRATIONS"] == "TRUE"
-      render 'new'
-    elsif @service_provider.save
+    if @service_provider.save
       session[:user_id] = @service_provider.user.id
       redirect_to users_verify_path
     else
-      assign_all_role_types
-      render 'users/new'
+      render 'new'
     end
   end
 

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -1,16 +1,19 @@
 class StudentsController < ApplicationController
-  before_filter :require_login, :require_student, except: :create
+  before_filter :require_login, :require_student, except: [:new, :create]
+  before_filter :require_no_login, only: [:new, :create]
+
+  def new
+    @student = Student.new
+    @student.build_user
+  end
 
   def create
     @student = Student.new(student_params)
-    if ENV["DISABLE_REGISTRATIONS"] == "TRUE"
-      render 'new'
-    elsif @student.save
+    if @student.save
       session[:user_id] = @student.user.id
       redirect_to users_verify_path
     else
-      assign_all_role_types
-      render 'users/new'
+      render 'new'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,18 +1,14 @@
 class UsersController < ApplicationController
   before_filter :require_login, except: [:new, :verify_email]
+  before_filter :require_no_login, only: :new
+  before_filter :require_registration_enabled, only: :new
 
   def new
-    if ENV["DISABLE_REGISTRATIONS"] == "TRUE"
-      flash[:notice] = "We're sorry, but registration is temporarily disabled."
-      redirect_to login_path
-    else
-      assign_all_role_types
-    end
   end
 
   def verification
     @user = current_user
-    redirect_to dashboard_path if @user.verified?
+    redirect_to home_path if @user.verified?
     unless @user.email_verified
       flash[:errors] ||= []
       msg = "Your email address has not been verified. Please " \

--- a/app/views/service_providers/new.html.erb
+++ b/app/views/service_providers/new.html.erb
@@ -1,0 +1,11 @@
+<div data-role="page">
+  <div data-role="header">
+    <h1>Create an Account</h1>
+  </div>
+  <div data-role="content">
+    <%= render 'form' %>
+  </div>
+  <div data-role="footer" data-position="fixed" data-tap-toggle="false" class="jqm-footer">
+    <%= render "shared/navbar" %>
+  </div>
+</div>

--- a/app/views/students/new.html.erb
+++ b/app/views/students/new.html.erb
@@ -1,0 +1,11 @@
+<div data-role="page">
+  <div data-role="header">
+    <h1>Create an Account</h1>
+  </div>
+  <div data-role="content">
+    <%= render 'form' %>
+  </div>
+  <div data-role="footer" data-position="fixed" data-tap-toggle="false" class="jqm-footer">
+    <%= render "shared/navbar" %>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,27 +2,12 @@
   <div data-role="header">
     <h1>Create an Account</h1>
   </div><!-- /header -->
-  <% if ENV["DISABLE_REGISTRATIONS"] == "TRUE" %>
-    We’re sorry, but we have temporarily disabled registration for new users while we investigate an issue with the system. Please try registering again later.
-  <% else %>
-    <div data-role="tabs">
-      <div data-role="navbar">
-          <ul>
-            <li><a href="#student" data-theme="a" data-ajax="false">Student</a></li>
-            <!-- <li><a href="#parent" data-theme="a" data-ajax="false">Parent</a></li> -->
-            <li><a href="#service-provider" data-theme="a" data-ajax="false">Service Provider</a></li>
-          </ul>
-      </div>
-      <div id="student" class="ui-content">
-        <%= render partial: "/students/form" %>
-      </div>
-      <!-- <div id="parent" class="ui-content"> -->
-      <!-- </div> -->
-      <div id="service-provider" class="ui-content">
-        <%= render partial: "/service_providers/form" %>
-      </div>
+  <div data-role="content">
+    <div data-role="controlgroup">
+      <%= link_to "Register as a student", new_student_path, data: { role: "button", ajax: false } %>
+      <%= link_to "Register as a service provider", new_service_provider_path, data: { role: "button", ajax: false } %>
     </div>
-  <% end %>
+  </div>
   <div data-role="footer" data-id="foo1" data-position="fixed">
     <%= render "shared/navbar" %><!-- /navbar -->
   </div><!-- /footer -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   mount RailsAdmin::Engine => '/admin', as: 'rails_admin'
+
+  namespace :service_provider do
+    root 'events#index'
+    resources :events, except: [:index]
+  end
+
   root 'welcome#index'
 
   get 'dashboard' => 'welcome#dashboard'
@@ -20,17 +26,12 @@ Rails.application.routes.draw do
   get 'users/verify-email' => 'users#verify_email'
   post 'users/verify-email' => 'users#resend_confirmation_email'
   resource :password_reset, except: [:index, :show, :update]
-  resource :student, only: [:create, :edit, :update, :destroy]
-  resource :parent, only: [:create, :edit, :update, :destroy]
-  resource :service_provider, only: [:create, :edit, :update, :destroy]
+  resource :student
+  resource :parent
+  resource :service_provider
 
   resources :events do
     resources :attendances
-  end
-
-  namespace :service_provider do
-    root 'events#index'
-    resources :events, except: [:index]
   end
 
   # The priority is based upon order of creation: first created -> highest priority.

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe ServiceProvidersController, type: :controller do
   let(:service_provider) { create(:verified_service_provider) }
 
+  describe "GET #new" do
+    specify { expect(response).to render_template("new") }
+    specify { expect(assigns(:service_provider)).to be_a_new(ServiceProvider) }
+    specify { expect(assigns(:service_provider).user).to be_a_new(User) }
+  end
+
   describe "POST #create" do
     context "with valid attributes" do
       before { post :create, service_provider: FactoryGirl.attributes_for(:service_provider) }

--- a/spec/controllers/service_providers_controller_spec.rb
+++ b/spec/controllers/service_providers_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe ServiceProvidersController, type: :controller do
   let(:service_provider) { create(:verified_service_provider) }
 
   describe "GET #new" do
+    before { get :new }
     specify { expect(response).to render_template("new") }
     specify { expect(assigns(:service_provider)).to be_a_new(ServiceProvider) }
     specify { expect(assigns(:service_provider).user).to be_a_new(User) }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe StudentsController, type: :controller do
   let(:student) { create(:verified_student) }
 
   describe "GET #new" do
+    before { get :new }
     specify { expect(response).to render_template("new") }
     specify { expect(assigns(:student)).to be_a_new(Student) }
     specify { expect(assigns(:student).user).to be_a_new(User) }

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -3,6 +3,12 @@ require 'rails_helper'
 RSpec.describe StudentsController, type: :controller do
   let(:student) { create(:verified_student) }
 
+  describe "GET #new" do
+    specify { expect(response).to render_template("new") }
+    specify { expect(assigns(:student)).to be_a_new(Student) }
+    specify { expect(assigns(:student).user).to be_a_new(User) }
+  end
+
   describe "POST #create" do
     context "with valid attributes" do
       before { post :create, student: FactoryGirl.attributes_for(:student) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -5,9 +5,6 @@ RSpec.describe UsersController do
   describe "GET #new" do
     before { get :new }
     specify { expect(response).to render_template("new") }
-    specify { expect(assigns(:student)).to be_a_new(Student) }
-    specify { expect(assigns(:parent)).to be_a_new(Parent) }
-    specify { expect(assigns(:service_provider)).to be_a_new(ServiceProvider) }
   end
 
   describe "GET #verification" do
@@ -21,7 +18,7 @@ RSpec.describe UsersController do
       specify { expect(response).to render_template("verification") }
     end
     context "with verified user" do
-      let(:user) { create(:user, phone_verified: true, email_verified: true) }
+      let(:user) { create(:verified_student).user }
       before { get :verification, nil, { user_id: user.id} }
       specify { expect(response).to redirect_to(dashboard_path) }
     end

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Visitor signs up", js: true do
     end
 
     scenario "With invalid information" do
-      visit register_path
+      visit new_student_path
       click_button "Submit"
       expect(page).to have_content("error")
       expect(page).to have_button("Submit")
@@ -29,10 +29,8 @@ RSpec.feature "Visitor signs up", js: true do
     end
 
     scenario "with invalid information" do
-      visit register_path
-      click_link "Service Provider"
+      visit new_service_provider_path
       click_button "Submit"
-      click_link "Service Provider"
       expect(page).to have_content("error")
       expect(page).to have_button("Submit")
       expect(page).not_to have_button("Verify")

--- a/spec/support/features/application_helpers.rb
+++ b/spec/support/features/application_helpers.rb
@@ -30,7 +30,7 @@ module Features
 
     def register_as_student(student = nil)
       student = build(:student) if student.nil?
-      visit register_path
+      visit new_student_path
       fill_in "Username", with: student.username
       fill_in "Email", with: student.user.email
       fill_in "Phone", with: student.user.phone
@@ -42,8 +42,7 @@ module Features
 
     def register_as_service_provider(service_provider = nil)
       service_provider = build(:service_provider) unless service_provider
-      visit register_path
-      click_link "Service Provider"
+      visit new_service_provider_path
       fill_in "Email", with: service_provider.user.email
       fill_in "Phone", with: service_provider.user.phone
       fill_in "Password", with: service_provider.user.password


### PR DESCRIPTION
Errors during registration will now be displayed immediately. Also simplifies/clarifies backend code considerably.
#483 