### PR TITLE
Require manual approval before students can send nudges

### DIFF
--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -8,7 +8,7 @@
   -webkit-overflow-scrolling: touch;
   }
 
-.notice {
+.message {
   width: 100%;
   padding-top: 8px;
   padding-bottom: 8px;
@@ -17,10 +17,19 @@
   font-size: 20px;
   -moz-border-radius: 6px;
   -webkit-border-radius: 6px;
-  background-color: yellowgreen;
   text-align: center;
   margin-bottom: 10px;
   text-shadow: none;
+}
+
+.notice {
+  @extend .message;
+  background-color: yellowgreen;
+}
+
+.warning {
+  @extend .message;
+  background-color: yellow;
 }
 
 #rwmh {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,6 +46,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_nudger_approval
+    unless current_student.can_nudge
+      flash[:warning] = "You cannot nudge other users until you have been approved by an administrator."
+      redirect_to Event.find(params[:event_id])
+    end
+  end
+
   def current_user
     @current_user ||= User.find_by_id(session[:user_id])
   end

--- a/app/controllers/nudges_controller.rb
+++ b/app/controllers/nudges_controller.rb
@@ -1,5 +1,6 @@
 class NudgesController < ApplicationController
 	before_filter :require_verified_user, :require_student
+	before_filter :require_nudger_approval, only: [:new, :create]
 	before_filter :nudges_enabled_globally?, only: [:new, :create]
 
 	def index

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -11,6 +11,8 @@ class Student < ActiveRecord::Base
   validates :username, presence: true, uniqueness: true
   validates :school_id, presence: true
 
+  before_validation :set_boolean_defaults
+
   def self.nudgeable(nudger, event)
     where(nudges_enabled: true)
       .where.not(id: nudger.id)
@@ -19,5 +21,12 @@ class Student < ActiveRecord::Base
 
   def send_text(body)
     user.send_text(body)
+  end
+
+  private
+
+  def set_boolean_defaults
+    self.can_nudge = can_nudge ? true : false
+    true
   end
 end

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -17,50 +17,55 @@
     <div class="pictures">
       <img src="https://703776390ca6a57878ac07d8581c71c708895809.googledrive.com/host/0B-EZWDUirQ46fjQtUzN1VG80eWdzdERtYjMzcTg3S19VeGlWR3FfUGJpOEFEZmtVQmh4SFk/Assets/Events/event<%=@rand_image_number%>.jpg" class="default_image"/>
     </div>
+    <% if flash[:warning] %>
+       <div class="warning">
+        <%= flash[:warning] %>
+      </div>
+    <% end %>
     <% if current_user and current_user.verified? %>
-    <% Nudge.where(event_id: @event.id, nudgee_id: current_student.id).each do |nudge| %>
-      <div class="notice">
-        <%= "You have been nudged by #{nudge.nudger.username}" %>
-        <%= form_tag(nudge, method: :delete, "data-ajax" => "false") do %>
-          <%= hidden_field_tag(:accept, true) %>
-          <%= submit_tag("Accept") %>
+      <% if @attend %>
+        <div class="notice" id="status">
+          <%= @attend.description %>
+        </div>
+      <% end %>
+      <% Nudge.where(event_id: @event.id, nudgee_id: current_student.id).each do |nudge| %>
+        <div class="notice">
+          <%= "You have been nudged by #{nudge.nudger.username}" %>
+          <%= form_tag(nudge, method: :delete, "data-ajax" => "false") do %>
+            <%= hidden_field_tag(:accept, true) %>
+            <%= submit_tag("Accept") %>
+          <% end %>
+          <button>Decline Nudge (Inactive)</button>
+        </div>
+      <% end %>
+      <% Nudge.where(event_id: @event.id, nudger_id: current_student.id).each do |nudge| %>
+        <div class="notice">
+          <%= "You have nudged #{@nudge.nudgee.username} and response is pending" %>
+        </div>
+      <% end %>
+      <div class="align-left" id="buttons">
+        <% unless (@attend && @attend.commitment_status == "Yes") %>
+          <%= form_tag(new_event_attendance_path(@event), method: "get", "data-ajax" => "false") do %>
+            <%= submit_tag("Join") %>
+          <% end %>
         <% end %>
-        <button>Decline Nudge (Inactive)</button>
-      </div>
-    <% end %>
-    <% Nudge.where(event_id: @event.id, nudger_id: current_student.id).each do |nudge| %>
-      <div class="notice">
-        <%= "You have nudged #{@nudge.nudgee.username} and response is pending" %>
-      </div>
-    <% end %>
-    <div class="align-left" id="buttons">
-      <% unless (@attend && @attend.commitment_status == "Yes") %>
-        <%= form_tag(new_event_attendance_path(@event), method: "get", "data-ajax" => "false") do %>
-          <%= submit_tag("Join") %>
+        <% unless @attend && ["Yes", "Maybe"].include?(@attend.commitment_status) %>
+          <%= form_tag(event_attendances_path(@event), method: "post", "data-ajax" => "false") do %>
+            <%= hidden_field_tag(:commitment_status, "Maybe") %>
+            <%= submit_tag("Watch") %>
+          <% end %>
+        <% end %>
+        <% if @attend && @attend.commitment_status == "Yes" %>
+          <%= form_tag(event_attendance_path(@event, @attend), method: "delete", "data-ajax" => "false") do %>
+            <%= submit_tag("Back Out") %>
+          <% end %>
+        <% end %>
+        <% unless session[:is_parent?]%>
+        <%= form_tag(new_event_nudge_path(@event), method: "get", "data-ajax" => "false") do %>
+          <%= submit_tag("Nudge") %>
         <% end %>
       <% end %>
-      <% unless @attend && ["Yes", "Maybe"].include?(@attend.commitment_status) %>
-        <%= form_tag(event_attendances_path(@event), method: "post", "data-ajax" => "false") do %>
-          <%= hidden_field_tag(:commitment_status, "Maybe") %>
-          <%= submit_tag("Watch") %>
-        <% end %>
-      <% end %>
-      <% if @attend && @attend.commitment_status == "Yes" %>
-        <%= form_tag(event_attendance_path(@event, @attend), method: "delete", "data-ajax" => "false") do %>
-          <%= submit_tag("Back Out") %>
-        <% end %>
-      <% end %>
-      <% unless session[:is_parent?]%>
-      <form method="GET" action="/events/<%=params[:id]%>/nudge">
-        <input type="submit" id="igiyg" value="Nudge"></input>
-      </form>
-      <%end%>
     </div>
-    <% if @attend %>
-      <div class="notice" id="status">
-        <%= @attend.description %>
-      </div>
-    <% end %>
     <% end %>
     <div class="align-left">
       <p><%="Description: " + @event.description %></p>

--- a/db/migrate/20160116181447_add_can_nudge_to_students.rb
+++ b/db/migrate/20160116181447_add_can_nudge_to_students.rb
@@ -1,0 +1,5 @@
+class AddCanNudgeToStudents < ActiveRecord::Migration
+  def change
+    add_column :students, :can_nudge, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028013713) do
+ActiveRecord::Schema.define(version: 20160116181447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20151028013713) do
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.boolean  "nudges_enabled"
+    t.boolean  "can_nudge"
   end
 
   add_index "students", ["username"], name: "index_students_on_username", unique: true, using: :btree

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
 
     factory :verified_student do
       user_attributes { FactoryGirl.attributes_for(:verified_user) }
+      can_nudge true
     end
   end
 


### PR DESCRIPTION
#489 

* Students must be approved (currently via the admin panel) before they can send nudges
* Adjust CSS to allow multiple colors for flash messages
* Fix bug that broke link to Nudges#new view