### PR TITLE
Fix typo that caused admin model specs to fail

### DIFF
--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Admin, type: :model do
   it "is invalid without a user" do
-    expect(build(:parent, user_attributes: {})).not_to be_valid
+    expect(build(:admin, user_attributes: {})).not_to be_valid
   end
 end


### PR DESCRIPTION
Fix mistake causing specs to fail improperly.
